### PR TITLE
Avoid undocumented usage of the head utility.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
+  $(type -p greadlink readlink | head -n1) "$1"
 }
 
 abs_dirname() {

--- a/libexec/bats
+++ b/libexec/bats
@@ -27,7 +27,7 @@ help() {
 }
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
+  $(type -p greadlink readlink | head -n1) "$1"
 }
 
 abs_dirname() {


### PR DESCRIPTION
Some implementations of head (e.g. the one in Busybox)
can't handle options like "-1". Replace them with "-n1".

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>